### PR TITLE
Implement and test methods to alter an existing deposit

### DIFF
--- a/src/UniStaker.sol
+++ b/src/UniStaker.sol
@@ -13,6 +13,7 @@ contract UniStaker is ReentrancyGuard {
   error UniStaker__Unauthorized(bytes32 reason, address caller);
   error UniStaker__InvalidRewardRate();
   error UniStaker__InsufficientRewardBalance();
+  error UniStaker__InvalidAddress();
 
   struct Deposit {
     uint256 balance;
@@ -102,6 +103,7 @@ contract UniStaker is ReentrancyGuard {
   }
 
   function alterDelegatee(DepositIdentifier _depositId, address _newDelegatee) public nonReentrant {
+    _revertIfAddressZero(_newDelegatee);
     Deposit storage deposit = deposits[_depositId];
     _revertIfNotDepositOwner(deposit);
 
@@ -115,6 +117,7 @@ contract UniStaker is ReentrancyGuard {
     public
     nonReentrant
   {
+    _revertIfAddressZero(_newBeneficiary);
     Deposit storage deposit = deposits[_depositId];
     _revertIfNotDepositOwner(deposit);
 
@@ -188,6 +191,9 @@ contract UniStaker is ReentrancyGuard {
     internal
     returns (DepositIdentifier _depositId)
   {
+    _revertIfAddressZero(_delegatee);
+    _revertIfAddressZero(_beneficiary);
+
     _updateReward(_beneficiary);
 
     DelegationSurrogate _surrogate = _fetchOrDeploySurrogate(_delegatee);
@@ -219,5 +225,9 @@ contract UniStaker is ReentrancyGuard {
 
   function _revertIfNotDepositOwner(Deposit storage deposit) internal view {
     if (msg.sender != deposit.owner) revert UniStaker__Unauthorized("not owner", msg.sender);
+  }
+
+  function _revertIfAddressZero(address _account) internal pure {
+    if (_account == address(0)) revert UniStaker__InvalidAddress();
   }
 }


### PR DESCRIPTION
This PR implements and tests methods that allow depositors to alter their existing deposits in some way. In particular, this includes methods that allow a depositor to:

* Add more stake to an existing deposit
* Update the delegatee of an existing deposit
* Update the beneficiary of an existing deposit

Additionally the PR implements a restriction on using the zero address as the delegatee or beneficiary. This is a business requirement from the stakeholders.