### PR TITLE
Expand unit test coverage on earn

### DIFF
--- a/test/UniStaker.t.sol
+++ b/test/UniStaker.t.sol
@@ -1966,7 +1966,7 @@ contract Earned is UniStakerRewardsTest {
     // Time moves forward with no rewards
     _jumpAheadByPercentOfRewardDuration(_noRewardsSkip);
 
-    // Send new rewards
+    // Send new rewards, which should have no impact on the amount earned until time elapses
     _mintTransferAndNotifyReward(_rewardAmount);
 
     // The user should have earned all the rewards
@@ -2036,7 +2036,7 @@ contract Earned is UniStakerRewardsTest {
     // Skip ahead with no rewards
     _jumpAheadByPercentOfRewardDuration(_noRewardsSkip);
 
-    // Send new rewards
+    // Send new rewards, which should have no impact on the amount earned until time elapses
     _mintTransferAndNotifyReward(_rewardAmount);
 
     // The beneficiaries should have earned all the rewards for the first duration


### PR DESCRIPTION
#### Description

- Expand unit test coverage on earn

### New tests
1. Calculates Correct Earnings For A Single User Stake For Partial Duration With A Beneficiary
1. Calculates Correct Earnings For A Single User That Deposits Partially Through The Duration With A Beneficiary
1. Calculates Correct Earnings For A Single User That Deposits Stake For The Full Duration With No New Rewards
1. Calculates Correct Earnings For A Single User That Deposits Stake For The Full Duration With Delayed Reward
1. Calculates Correct Earnings When A Single Depositor Updates Their Beneficiary With No New Rewards
1. Calculates Correct Earnings For A Single User That Deposits Stake For The Full Duration And Claims
1. Calculates Correct Earnings For A Single User That Deposits Stake For The Partial Duration And Claims
1. Calculates Correct Earnings For Two Users That Deposit Equal Stake For Full Duration And Both Claim
1. Calculates Correct Earnings For Two Users When One Stakes More Partially Through The Duration And One Claims
1. Calculates Correct Earnings For Four Users That Deposit Equal Stake For Full Duration Where One Is A Beneficiary Of Two Others
1. Calculates Correct Earnings For Four Users When One Stakes More Partially Through The Duration And Two Beneficiaries
1.  Calculates Correct Earnings For Four Users When Two Stake More Partially Through The Duration And One Beneficiary
1. Calculates Correct Earnings When A User Deposits And There Are Three Rewards
1. Calculates Correct Earnings When Two Users Deposit For Partial Durations And There Are Three Rewards
1. Calculates Correct Earnings When Two Users Deposit Different Amounts For Partial Durations And There Are Three Rewards




Closes #28 