### PR TITLE
Remove ability of V3FactoryOwner to transfer factory ownership

### DIFF
--- a/src/V3FactoryOwner.sol
+++ b/src/V3FactoryOwner.sol
@@ -99,15 +99,6 @@ contract V3FactoryOwner {
     admin = _newAdmin;
   }
 
-  /// @notice Passthrough method that transfers ownership of the factory from this contract to a
-  /// specified new address. Must be called by the admin.
-  /// @param _newOwner The address that will serve as the factory's owner after this call
-  /// completes.
-  function transferFactoryOwnership(address _newOwner) external {
-    _revertIfNotAdmin();
-    FACTORY.setOwner(_newOwner);
-  }
-
   /// @notice Passthrough method that enables a fee amount on the factory. Must be called by the
   /// admin.
   /// @param _fee The fee param to forward to the factory.

--- a/test/V3FactoryOwner.t.sol
+++ b/test/V3FactoryOwner.t.sol
@@ -146,26 +146,6 @@ contract SetAdmin is V3FactoryOwnerTest {
   }
 }
 
-contract TransferFactoryOwnership is V3FactoryOwnerTest {
-  function testFuzz_ForwardsNewOwnerToSetOwnerMethodOnFactory(address _newOwner) public {
-    _deployFactoryOwnerWithPayoutAmount(0);
-
-    vm.prank(admin);
-    factoryOwner.transferFactoryOwnership(_newOwner);
-
-    assertEq(factory.lastParam__setOwner_owner(), _newOwner);
-  }
-
-  function testFuzz_RevertIf_TheCallerIsNotTheAdmin(address _notAdmin, address _newOwner) public {
-    _deployFactoryOwnerWithPayoutAmount(0);
-    vm.assume(_notAdmin != admin);
-
-    vm.expectRevert(V3FactoryOwner.V3FactoryOwner__Unauthorized.selector);
-    vm.prank(_notAdmin);
-    factoryOwner.transferFactoryOwnership(_newOwner);
-  }
-}
-
 contract EnableFeeAmount is V3FactoryOwnerTest {
   function testFuzz_ForwardsParametersToTheEnableFeeAmountMethodOnTheFactory(
     uint24 _fee,


### PR DESCRIPTION
As requested by stakeholders, remove the ability of the V3 Factory Owner contract to transfer ownership in the future.