### PR TITLE
Permit based stake and stakeMore methods

### DIFF
--- a/src/UniStaker.sol
+++ b/src/UniStaker.sol
@@ -275,6 +275,33 @@ contract UniStaker is INotifiableRewardReceiver, ReentrancyGuard, Multicall, EIP
     _depositId = _stake(msg.sender, _amount, _delegatee, _beneficiary);
   }
 
+  /// @notice Method to stake tokens to a new deposit. The caller must approve the staking
+  /// contract to spend at least the would-be staked amount of the token via a signature which is
+  /// is also provided, and is passed to the token contract's permit method before the staking
+  /// operation occurs.
+  /// @param _amount Quantity of the staking token to stake.
+  /// @param _delegatee Address to assign the governance voting weight of the staked tokens.
+  /// @param _beneficiary Address that will accrue rewards for this stake.
+  /// @param _deadline The timestamp at which the permit signature should expire.
+  /// @param _v ECDSA signature component: Parity of the `y` coordinate of point `R`
+  /// @param _r ECDSA signature component: x-coordinate of `R`
+  /// @param _s ECDSA signature component: `s` value of the signature
+  /// @return _depositId Unique identifier for this deposit.
+  /// @dev Neither the delegatee nor the beneficiary may be the zero address. The deposit will be
+  /// owned by the message sender.
+  function permitAndStake(
+    uint256 _amount,
+    address _delegatee,
+    address _beneficiary,
+    uint256 _deadline,
+    uint8 _v,
+    bytes32 _r,
+    bytes32 _s
+  ) external nonReentrant returns (DepositIdentifier _depositId) {
+    STAKE_TOKEN.permit(msg.sender, address(this), _amount, _deadline, _v, _r, _s);
+    _depositId = _stake(msg.sender, _amount, _delegatee, _beneficiary);
+  }
+
   /// @notice Stake tokens to a new deposit on behalf of a user, using a signature to validate the
   /// user's intent. The caller must pre-approve the staking contract to spend at least the
   /// would-be staked amount of the token.
@@ -315,6 +342,33 @@ contract UniStaker is INotifiableRewardReceiver, ReentrancyGuard, Multicall, EIP
   function stakeMore(DepositIdentifier _depositId, uint256 _amount) external nonReentrant {
     Deposit storage deposit = deposits[_depositId];
     _revertIfNotDepositOwner(deposit, msg.sender);
+    _stakeMore(deposit, _depositId, _amount);
+  }
+
+  /// @notice Add more staking tokens to an existing deposit. A staker should call this method when
+  /// they have an existing deposit, and wish to stake more while retaining the same delegatee and
+  /// beneficiary. The caller must approve the staking contract to spend at least the would-be
+  /// staked amount of the token via a signature which is is also provided, and is passed to the
+  /// token contract's permit method before the staking operation occurs.
+  /// @param _depositId Unique identifier of the deposit to which stake will be added.
+  /// @param _amount Quantity of stake to be added.
+  /// @param _deadline The timestamp at which the permit signature should expire.
+  /// @param _v ECDSA signature component: Parity of the `y` coordinate of point `R`
+  /// @param _r ECDSA signature component: x-coordinate of `R`
+  /// @param _s ECDSA signature component: `s` value of the signature
+  /// @dev The message sender must be the owner of the deposit.
+  function permitAndStakeMore(
+    DepositIdentifier _depositId,
+    uint256 _amount,
+    uint256 _deadline,
+    uint8 _v,
+    bytes32 _r,
+    bytes32 _s
+  ) external nonReentrant {
+    Deposit storage deposit = deposits[_depositId];
+    _revertIfNotDepositOwner(deposit, msg.sender);
+
+    STAKE_TOKEN.permit(msg.sender, address(this), _amount, _deadline, _v, _r, _s);
     _stakeMore(deposit, _depositId, _amount);
   }
 

--- a/src/interfaces/IERC20Delegates.sol
+++ b/src/interfaces/IERC20Delegates.sol
@@ -15,6 +15,15 @@ interface IERC20Delegates {
   function totalSupply() external view returns (uint256);
   function transfer(address dst, uint256 rawAmount) external returns (bool);
   function transferFrom(address src, address dst, uint256 rawAmount) external returns (bool);
+  function permit(
+    address owner,
+    address spender,
+    uint256 rawAmount,
+    uint256 deadline,
+    uint8 v,
+    bytes32 r,
+    bytes32 s
+  ) external;
 
   // ERC20Votes delegation methods
   function delegate(address delegatee) external;

--- a/test/mocks/MockERC20Votes.sol
+++ b/test/mocks/MockERC20Votes.sol
@@ -1,17 +1,18 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity 0.8.23;
 
-import {ERC20} from "openzeppelin/token/ERC20/ERC20.sol";
 import {IERC20Delegates} from "src/interfaces/IERC20Delegates.sol";
+import {ERC20, ERC20Permit} from "openzeppelin/token/ERC20/extensions/ERC20Permit.sol";
 
-/// @dev An ERC20 token that allows for public minting and mocks the delegation methods used in
-/// ERC20Votes governance tokens. It does not included check pointing functionality. This contract
-/// is intended only for use as a stand in for contracts that interface with ERC20Votes tokens.
-contract ERC20VotesMock is IERC20Delegates, ERC20 {
+/// @dev An ERC20Permit token that allows for public minting and mocks the delegation methods used
+/// in ERC20Votes governance tokens. It does not included check pointing functionality. This
+/// contract is intended only for use as a stand in for contracts that interface with ERC20Votes
+// tokens.
+contract ERC20VotesMock is IERC20Delegates, ERC20Permit {
   /// @dev Track delegations for mocked delegation methods
   mapping(address account => address delegate) private delegations;
 
-  constructor() ERC20("Governance Token", "GOV") {}
+  constructor() ERC20("Governance Token", "GOV") ERC20Permit("Governance Token") {}
 
   /// @dev Public mint function useful for testing
   function mint(address _account, uint256 _value) public {
@@ -87,5 +88,17 @@ contract ERC20VotesMock is IERC20Delegates, ERC20 {
     returns (bool)
   {
     return ERC20.transferFrom(src, dst, rawAmount);
+  }
+
+  function permit(
+    address owner,
+    address spender,
+    uint256 rawAmount,
+    uint256 deadline,
+    uint8 v,
+    bytes32 r,
+    bytes32 s
+  ) public override(IERC20Delegates, ERC20Permit) {
+    return ERC20Permit.permit(owner, spender, rawAmount, deadline, v, r, s);
   }
 }


### PR DESCRIPTION
This PR implements permit-based `stake` and `stakeMore` methods. These methods perform the approval on the staking token atomically using the `permit` extension. These convenience methods allow for slightly better UX when staking: instead of submitting an approval transaction and a stake transaction, the user first signs the approval then submits the signature and staking parameters to these methods.

Note that for testing bad signatures, we are *not* aiming for exhaustive tests of various ways the signature can be invalid, because we're not testing the `permit` implementation, just sanity checking our contract behaves as expected, passing the parameters forward to the token contract.