### PR TITLE
Leave the scale factor into the unclaimed reward calculations

### DIFF
--- a/src/UniStaker.sol
+++ b/src/UniStaker.sol
@@ -241,7 +241,7 @@ contract UniStaker is INotifiableRewardReceiver, Multicall, EIP712, Nonces {
   /// Note that the contract tracks the unclaimed rewards internally with the scale factor
   /// included, in order to avoid the accrual of precision losses as users takes actions that
   /// cause rewards to be checkpointed. This external helper method is useful for integrations, and
-  /// returns the value after it  has been scaled down to the reward token's raw decimal amount.
+  /// returns the value after it has been scaled down to the reward token's raw decimal amount.
   /// @return Live value of the unclaimed rewards earned by a given beneficiary account.
   function unclaimedReward(address _beneficiary) external view returns (uint256) {
     return _scaledUnclaimedReward(_beneficiary) / SCALE_FACTOR;

--- a/test/UniStaker.integration.t.sol
+++ b/test/UniStaker.integration.t.sol
@@ -265,7 +265,7 @@ contract Stake is IntegrationTest, PercentAssertions {
   ) public {
     vm.assume(_depositor != address(0) && _delegatee != address(0) && _amount != 0);
     // Make sure depositor is not UniStaker
-    vm.assume(_depositor != 0xE2307e3710d108ceC7a4722a020a050681c835b3);
+    vm.assume(_depositor != address(uniStaker));
     _passQueueAndExecuteProposals();
     _swapAndClaimFees(_swapAmount);
     _amount = _dealStakingToken(_depositor, _amount);

--- a/test/helpers/UniStaker.handler.sol
+++ b/test/helpers/UniStaker.handler.sol
@@ -157,7 +157,8 @@ contract UniStakerHandler is CommonBase, StdCheats, StdUtils {
   function claimReward(uint256 _actorSeed) public countCall("claimReward") doCheckpoints {
     _useActor(_beneficiaries, _actorSeed);
     vm.startPrank(_currentActor);
-    uint256 rewardsClaimed = uniStaker.unclaimedRewardCheckpoint(_currentActor);
+    uint256 rewardsClaimed =
+      uniStaker.scaledUnclaimedRewardCheckpoint(_currentActor) / uniStaker.SCALE_FACTOR();
     uniStaker.claimReward();
     vm.stopPrank();
     ghost_rewardsClaimed += rewardsClaimed;


### PR DESCRIPTION
To avoid the accrual of precision loss as unclaimed rewards are calculated and checkpointed, we leave the scale factor in the unclaimed reward checkpoints. Our unclaimed reward method becomes a helper function only. We also add a test to ensure this precision loss does not accrue to a meaningful degree, even in extreme conditions.

closes #70 