### PR TITLE
Improvements to the Repository for usage as a dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,8 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
+    env:
+      FOUNDRY_PROFILE: coverage
     steps:
       - uses: actions/checkout@v3
 
@@ -118,23 +120,23 @@ jobs:
           scopelint --version
           scopelint check
 
-  # slither-analyze:
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     contents: read
-  #     security-events: write
-  #   steps:
-  #     - uses: actions/checkout@v3
+  slither-analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v3
 
-  #     - name: Run Slither
-  #       uses: crytic/slither-action@v0.3.0
-  #       id: slither # Required to reference this step in the next step.
-  #       with:
-  #         fail-on: none # Required to avoid failing the CI run regardless of findings.
-  #         sarif: results.sarif
-  #         slither-args: --filter-paths "./lib|./test" --exclude naming-convention,solc-version
+      - name: Run Slither
+        uses: crytic/slither-action@v0.3.0
+        id: slither # Required to reference this step in the next step.
+        with:
+          fail-on: none # Required to avoid failing the CI run regardless of findings.
+          sarif: results.sarif
+          slither-args: --filter-paths "./lib|./test" --exclude naming-convention,solc-version
 
-  #     - name: Upload SARIF file
-  #       uses: github/codeql-action/upload-sarif@v2
-  #       with:
-  #         sarif_file: ${{ steps.slither.outputs.sarif }}
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: ${{ steps.slither.outputs.sarif }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "lib/forge-std"]
-	path = lib/forge-std
-	url = https://github.com/foundry-rs/forge-std
 [submodule "lib/openzeppelin-contracts"]
 	path = lib/openzeppelin-contracts
 	url = https://github.com/openzeppelin/openzeppelin-contracts
@@ -10,3 +7,6 @@
 [submodule "lib/v3-periphery"]
 	path = lib/v3-periphery
 	url = https://github.com/uniswap/v3-periphery
+[submodule "lib/forge-std"]
+	path = lib/forge-std
+	url = https://github.com/foundry-rs/forge-std

--- a/foundry.toml
+++ b/foundry.toml
@@ -2,17 +2,16 @@
   evm_version = "paris"
   optimizer = true
   optimizer_runs = 10_000_000
-  remappings = [
-    "openzeppelin/=lib/openzeppelin-contracts/contracts",
-    "uniswap-periphery/=lib/v3-periphery/contracts",
-    "@uniswap/v3-core=lib/v3-core",
-  ]
   solc_version = "0.8.23"
   verbosity = 3
 
 [profile.ci]
   fuzz = { runs = 5000 }
   invariant = { runs = 1000 }
+
+[profile.coverage]
+  fuzz = { runs = 100 }
+  invariant = { runs = 0 }
 
 [profile.lite]
   fuzz = { runs = 50 }

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,0 +1,5 @@
+unistaker=src/
+unistaker-test=test/
+unistaker-script=script/
+uniswap-periphery/=lib/v3-periphery/contracts
+@uniswap/v3-core=lib/v3-core

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // slither-disable-start reentrancy-benign
 
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
-import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {Script} from "forge-std/Script.sol";
 
-import {DeployInput} from "script/DeployInput.sol";
-import {UniStaker} from "src/UniStaker.sol";
-import {V3FactoryOwner} from "src/V3FactoryOwner.sol";
-import {IERC20Delegates} from "src/interfaces/IERC20Delegates.sol";
-import {INotifiableRewardReceiver} from "src/interfaces/INotifiableRewardReceiver.sol";
-import {IUniswapV3FactoryOwnerActions} from "src/interfaces/IUniswapV3FactoryOwnerActions.sol";
+import {DeployInput} from "unistaker-script/DeployInput.sol";
+import {UniStaker} from "unistaker/UniStaker.sol";
+import {V3FactoryOwner} from "unistaker/V3FactoryOwner.sol";
+import {IERC20Delegates} from "unistaker/interfaces/IERC20Delegates.sol";
+import {INotifiableRewardReceiver} from "unistaker/interfaces/INotifiableRewardReceiver.sol";
+import {IUniswapV3FactoryOwnerActions} from "unistaker/interfaces/IUniswapV3FactoryOwnerActions.sol";
 
 contract Deploy is Script, DeployInput {
   uint256 deployerPrivateKey;

--- a/script/DeployInput.sol
+++ b/script/DeployInput.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // slither-disable-start reentrancy-benign
 
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 contract DeployInput {
   address constant UNISWAP_GOVERNOR = 0x408ED6354d4973f66138C91495F2f2FCbd8724C3;

--- a/script/ProposeFactorySetOwner.s.sol
+++ b/script/ProposeFactorySetOwner.s.sol
@@ -3,8 +3,8 @@ pragma solidity ^0.8.23;
 
 import {Script} from "forge-std/Script.sol";
 
-import {DeployInput} from "script/DeployInput.sol";
-import {GovernorBravoDelegate} from "script/interfaces/GovernorBravoInterfaces.sol";
+import {DeployInput} from "unistaker-script/DeployInput.sol";
+import {GovernorBravoDelegate} from "unistaker-script/interfaces/GovernorBravoInterfaces.sol";
 
 contract ProposeFactorySetOwner is Script, DeployInput {
   GovernorBravoDelegate constant GOVERNOR = GovernorBravoDelegate(UNISWAP_GOVERNOR);

--- a/script/ProposeProtocolFeesBase.s.sol
+++ b/script/ProposeProtocolFeesBase.s.sol
@@ -3,8 +3,8 @@ pragma solidity ^0.8.23;
 
 import {Script} from "forge-std/Script.sol";
 
-import {DeployInput} from "script/DeployInput.sol";
-import {GovernorBravoDelegate} from "script/interfaces/GovernorBravoInterfaces.sol";
+import {DeployInput} from "unistaker-script/DeployInput.sol";
+import {GovernorBravoDelegate} from "unistaker-script/interfaces/GovernorBravoInterfaces.sol";
 
 /// @dev A new proposal script that updates a pool's fee settings should inherit this abstract
 /// script and implement `getPoolFeeSettings`.

--- a/script/ProposeProtocolFeesBatch1.sol
+++ b/script/ProposeProtocolFeesBatch1.sol
@@ -2,10 +2,7 @@
 pragma solidity ^0.8.23;
 
 import {Script} from "forge-std/Script.sol";
-
-import {DeployInput} from "script/DeployInput.sol";
-import {GovernorBravoDelegate} from "script/interfaces/GovernorBravoInterfaces.sol";
-import {ProposeProtocolFeesBase} from "script/ProposeProtocolFeesBase.s.sol";
+import {ProposeProtocolFeesBase} from "unistaker-script/ProposeProtocolFeesBase.s.sol";
 
 /// @dev This script will turn on protocol fees for the following pools: WBTC-WETH-3000,
 /// DAI-WETH-300, and DAI-USDC-100.

--- a/src/DelegationSurrogate.sol
+++ b/src/DelegationSurrogate.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
-import {IERC20Delegates} from "src/interfaces/IERC20Delegates.sol";
+import {IERC20Delegates} from "unistaker/interfaces/IERC20Delegates.sol";
 
 /// @title DelegationSurrogate
 /// @author ScopeLift

--- a/src/UniStaker.sol
+++ b/src/UniStaker.sol
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
-import {DelegationSurrogate} from "src/DelegationSurrogate.sol";
-import {INotifiableRewardReceiver} from "src/interfaces/INotifiableRewardReceiver.sol";
-import {IERC20Delegates} from "src/interfaces/IERC20Delegates.sol";
-import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
-import {SafeERC20} from "openzeppelin/token/ERC20/utils/SafeERC20.sol";
-import {Multicall} from "openzeppelin/utils/Multicall.sol";
-import {Nonces} from "openzeppelin/utils/Nonces.sol";
-import {SignatureChecker} from "openzeppelin/utils/cryptography/SignatureChecker.sol";
-import {EIP712} from "openzeppelin/utils/cryptography/EIP712.sol";
+import {DelegationSurrogate} from "unistaker/DelegationSurrogate.sol";
+import {INotifiableRewardReceiver} from "unistaker/interfaces/INotifiableRewardReceiver.sol";
+import {IERC20Delegates} from "unistaker/interfaces/IERC20Delegates.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Multicall} from "@openzeppelin/contracts/utils/Multicall.sol";
+import {Nonces} from "@openzeppelin/contracts/utils/Nonces.sol";
+import {SignatureChecker} from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
+import {EIP712} from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
 
 /// @title UniStaker
 /// @author ScopeLift

--- a/src/V3FactoryOwner.sol
+++ b/src/V3FactoryOwner.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
-import {IUniswapV3PoolOwnerActions} from "src/interfaces/IUniswapV3PoolOwnerActions.sol";
-import {IUniswapV3FactoryOwnerActions} from "src/interfaces/IUniswapV3FactoryOwnerActions.sol";
-import {INotifiableRewardReceiver} from "src/interfaces/INotifiableRewardReceiver.sol";
-import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
-import {SafeERC20} from "openzeppelin/token/ERC20/utils/SafeERC20.sol";
+import {IUniswapV3PoolOwnerActions} from "unistaker/interfaces/IUniswapV3PoolOwnerActions.sol";
+import {IUniswapV3FactoryOwnerActions} from "unistaker/interfaces/IUniswapV3FactoryOwnerActions.sol";
+import {INotifiableRewardReceiver} from "unistaker/interfaces/INotifiableRewardReceiver.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 /// @title V3FactoryOwner
 /// @author ScopeLift

--- a/test/DelegationSurrogate.t.sol
+++ b/test/DelegationSurrogate.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import {Test, console2} from "forge-std/Test.sol";
-import {DelegationSurrogate} from "src/DelegationSurrogate.sol";
-import {ERC20VotesMock} from "test/mocks/MockERC20Votes.sol";
+import {DelegationSurrogate} from "unistaker/DelegationSurrogate.sol";
+import {ERC20VotesMock} from "unistaker-test/mocks/MockERC20Votes.sol";
 
 contract DelegationSurrogateTest is Test {
   ERC20VotesMock govToken;

--- a/test/UniStaker.integration.t.sol
+++ b/test/UniStaker.integration.t.sol
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
-import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {Test, console2} from "forge-std/Test.sol";
-import {Deploy} from "script/Deploy.s.sol";
-import {DeployInput} from "script/DeployInput.sol";
+import {Deploy} from "unistaker-script/Deploy.s.sol";
+import {DeployInput} from "unistaker-script/DeployInput.sol";
 
-import {V3FactoryOwner} from "src/V3FactoryOwner.sol";
-import {UniStaker} from "src/UniStaker.sol";
-import {IUniswapV3FactoryOwnerActions} from "src/interfaces/IUniswapV3FactoryOwnerActions.sol";
-import {IUniswapV3PoolOwnerActions} from "src/interfaces/IUniswapV3PoolOwnerActions.sol";
-import {IUniswapPool} from "test/helpers/interfaces/IUniswapPool.sol";
-import {PercentAssertions} from "test/helpers/PercentAssertions.sol";
-import {IntegrationTest} from "test/helpers/IntegrationTest.sol";
+import {V3FactoryOwner} from "unistaker/V3FactoryOwner.sol";
+import {UniStaker} from "unistaker/UniStaker.sol";
+import {IUniswapV3FactoryOwnerActions} from "unistaker/interfaces/IUniswapV3FactoryOwnerActions.sol";
+import {IUniswapV3PoolOwnerActions} from "unistaker/interfaces/IUniswapV3PoolOwnerActions.sol";
+import {IUniswapPool} from "unistaker-test/helpers/interfaces/IUniswapPool.sol";
+import {PercentAssertions} from "unistaker-test/helpers/PercentAssertions.sol";
+import {IntegrationTest} from "unistaker-test/helpers/IntegrationTest.sol";
 
 contract DeployScriptTest is Test, DeployInput {
   function setUp() public {

--- a/test/UniStaker.invariants.t.sol
+++ b/test/UniStaker.invariants.t.sol
@@ -2,12 +2,12 @@
 pragma solidity ^0.8.23;
 
 import {Test} from "forge-std/Test.sol";
-import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-import {UniStaker} from "src/UniStaker.sol";
-import {UniStakerHandler} from "test/helpers/UniStaker.handler.sol";
-import {ERC20VotesMock} from "test/mocks/MockERC20Votes.sol";
-import {ERC20Fake} from "test/fakes/ERC20Fake.sol";
+import {UniStaker} from "unistaker/UniStaker.sol";
+import {UniStakerHandler} from "unistaker-test/helpers/UniStaker.handler.sol";
+import {ERC20VotesMock} from "unistaker-test/mocks/MockERC20Votes.sol";
+import {ERC20Fake} from "unistaker-test/fakes/ERC20Fake.sol";
 
 contract UniStakerInvariants is Test {
   UniStakerHandler public handler;
@@ -56,11 +56,14 @@ contract UniStakerInvariants is Test {
     assertEq(uniStaker.totalStaked(), handler.reduceDelegates(0, this.accumulateSurrogateBalance));
   }
 
-  function invariant_Cumulative_staked_minus_withdrawals_equals_total_stake() public {
+  function invariant_Cumulative_staked_minus_withdrawals_equals_total_stake() public view {
     assertEq(uniStaker.totalStaked(), handler.ghost_stakeSum() - handler.ghost_stakeWithdrawn());
   }
 
-  function invariant_Sum_of_notified_rewards_equals_all_claimed_rewards_plus_rewards_left() public {
+  function invariant_Sum_of_notified_rewards_equals_all_claimed_rewards_plus_rewards_left()
+    public
+    view
+  {
     assertEq(
       handler.ghost_rewardsNotified(),
       rewardToken.balanceOf(address(uniStaker)) + handler.ghost_rewardsClaimed()
@@ -75,7 +78,7 @@ contract UniStakerInvariants is Test {
   }
 
   function invariant_RewardPerTokenAccumulatedCheckpoint_should_be_greater_or_equal_to_the_last_rewardPerTokenAccumulatedCheckpoint(
-  ) public {
+  ) public view {
     assertGe(
       uniStaker.rewardPerTokenAccumulatedCheckpoint(),
       handler.ghost_prevRewardPerTokenAccumulatedCheckpoint()

--- a/test/UniStaker.t.sol
+++ b/test/UniStaker.t.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import {Vm, Test, stdStorage, StdStorage, console2} from "forge-std/Test.sol";
-import {UniStaker, DelegationSurrogate, IERC20, IERC20Delegates} from "src/UniStaker.sol";
-import {UniStakerHarness} from "test/harnesses/UniStakerHarness.sol";
-import {ERC20VotesMock, ERC20Permit} from "test/mocks/MockERC20Votes.sol";
-import {IERC20Errors} from "openzeppelin/interfaces/draft-IERC6093.sol";
-import {ERC20Fake} from "test/fakes/ERC20Fake.sol";
-import {PercentAssertions} from "test/helpers/PercentAssertions.sol";
+import {UniStaker, DelegationSurrogate, IERC20, IERC20Delegates} from "unistaker/UniStaker.sol";
+import {UniStakerHarness} from "unistaker-test/harnesses/UniStakerHarness.sol";
+import {ERC20VotesMock} from "unistaker-test/mocks/MockERC20Votes.sol";
+import {IERC20Errors} from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
+import {ERC20Fake} from "unistaker-test/fakes/ERC20Fake.sol";
+import {PercentAssertions} from "unistaker-test/helpers/PercentAssertions.sol";
 
 contract UniStakerTest is Test, PercentAssertions {
   ERC20Fake rewardToken;
@@ -191,7 +191,7 @@ contract UniStakerTest is Test, PercentAssertions {
 }
 
 contract Constructor is UniStakerTest {
-  function test_SetsTheRewardTokenStakeTokenAndRewardNotifier() public {
+  function test_SetsTheRewardTokenStakeTokenAndRewardNotifier() public view {
     assertEq(address(uniStaker.REWARD_TOKEN()), address(rewardToken));
     assertEq(address(uniStaker.STAKE_TOKEN()), address(govToken));
     assertEq(uniStaker.admin(), admin);
@@ -675,6 +675,9 @@ contract Stake is UniStakerTest {
 
     UniStaker.DepositIdentifier _depositId;
 
+    // The test performs thousands of operations, so we disable gas metering to prevent failure.
+    vm.pauseGasMetering();
+
     // Repeat the deposit over and over ensuring a new DepositIdentifier is assigned each time.
     for (uint256 _i; _i < 5000; _i++) {
       // Perform the stake and save the deposit identifier
@@ -705,6 +708,7 @@ contract Stake is UniStakerTest {
       _amount = uint96(uint256(keccak256(abi.encode(_amount))));
       _delegatee = address(uint160(uint256(keccak256(abi.encode(_delegatee)))));
     }
+    vm.resumeGasMetering();
   }
 
   function testFuzz_RevertIf_DelegateeIsTheZeroAddress(address _depositor, uint96 _amount) public {
@@ -2741,7 +2745,7 @@ contract Withdraw is UniStakerTest {
   ) public {
     UniStaker.DepositIdentifier _depositId;
     (_amount, _depositId) = _boundMintAndStake(_depositor, _amount, _delegatee);
-    _amountOver = uint96(bound(_amountOver, 1, type(uint128).max));
+    _amountOver = uint96(bound(_amountOver, 1, type(uint48).max));
 
     vm.prank(_depositor);
     vm.expectRevert();
@@ -3349,7 +3353,7 @@ contract NotifyRewardAmount is UniStakerRewardsTest {
 }
 
 contract LastTimeRewardDistributed is UniStakerRewardsTest {
-  function test_ReturnsZeroBeforeARewardNotificationHasOccurred() public {
+  function test_ReturnsZeroBeforeARewardNotificationHasOccurred() public view {
     assertEq(uniStaker.lastTimeRewardDistributed(), 0);
   }
 

--- a/test/V3FactoryOwner.t.sol
+++ b/test/V3FactoryOwner.t.sol
@@ -1,17 +1,16 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import {Test, console2} from "forge-std/Test.sol";
-import {V3FactoryOwner} from "src/V3FactoryOwner.sol";
-import {INotifiableRewardReceiver} from "src/interfaces/INotifiableRewardReceiver.sol";
-import {IUniswapV3PoolOwnerActions} from "src/interfaces/IUniswapV3PoolOwnerActions.sol";
-import {IUniswapV3FactoryOwnerActions} from "src/interfaces/IUniswapV3FactoryOwnerActions.sol";
-import {ERC20Fake} from "test/fakes/ERC20Fake.sol";
-import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
-import {IERC20Errors} from "openzeppelin/interfaces/draft-IERC6093.sol";
-import {MockRewardReceiver} from "test/mocks/MockRewardReceiver.sol";
-import {MockUniswapV3Pool} from "test/mocks/MockUniswapV3Pool.sol";
-import {MockUniswapV3Factory} from "test/mocks/MockUniswapV3Factory.sol";
+import {V3FactoryOwner} from "unistaker/V3FactoryOwner.sol";
+import {INotifiableRewardReceiver} from "unistaker/interfaces/INotifiableRewardReceiver.sol";
+import {IUniswapV3FactoryOwnerActions} from "unistaker/interfaces/IUniswapV3FactoryOwnerActions.sol";
+import {ERC20Fake} from "unistaker-test/fakes/ERC20Fake.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20Errors} from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
+import {MockRewardReceiver} from "unistaker-test/mocks/MockRewardReceiver.sol";
+import {MockUniswapV3Pool} from "unistaker-test/mocks/MockUniswapV3Pool.sol";
+import {MockUniswapV3Factory} from "unistaker-test/mocks/MockUniswapV3Factory.sol";
 
 contract V3FactoryOwnerTest is Test {
   V3FactoryOwner factoryOwner;

--- a/test/fakes/ERC20Fake.sol
+++ b/test/fakes/ERC20Fake.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
-import {ERC20} from "openzeppelin/token/ERC20/ERC20.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 /// @dev An ERC20 token that allows for public minting for use in tests.
 contract ERC20Fake is ERC20 {

--- a/test/harnesses/UniStakerHarness.sol
+++ b/test/harnesses/UniStakerHarness.sol
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
-import {DelegationSurrogate} from "src/DelegationSurrogate.sol";
-import {UniStaker} from "src/UniStaker.sol";
+import {DelegationSurrogate} from "unistaker/DelegationSurrogate.sol";
+import {UniStaker} from "unistaker/UniStaker.sol";
 
-import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
-import {SafeERC20} from "openzeppelin/token/ERC20/utils/SafeERC20.sol";
-import {IERC20Delegates} from "src/interfaces/IERC20Delegates.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20Delegates} from "unistaker/interfaces/IERC20Delegates.sol";
 
 contract UniStakerHarness is UniStaker {
   constructor(IERC20 _rewardsToken, IERC20Delegates _stakeToken, address _admin)

--- a/test/helpers/IntegrationTest.sol
+++ b/test/helpers/IntegrationTest.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import {console2, stdStorage, StdStorage} from "forge-std/Test.sol";
-import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
-import {IUniswapV3PoolOwnerActions} from "src/interfaces/IUniswapV3PoolOwnerActions.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IUniswapV3PoolOwnerActions} from "unistaker/interfaces/IUniswapV3PoolOwnerActions.sol";
 import {ISwapRouter} from "v3-periphery/interfaces/ISwapRouter.sol";
-import {ProposalTest} from "test/helpers/ProposalTest.sol";
-import {IERC20Mint} from "test/helpers/interfaces/IERC20Mint.sol";
+import {ProposalTest} from "unistaker-test/helpers/ProposalTest.sol";
+import {IERC20Mint} from "unistaker-test/helpers/interfaces/IERC20Mint.sol";
 
 contract IntegrationTest is ProposalTest {
   using stdStorage for StdStorage;

--- a/test/helpers/PercentAssertions.sol
+++ b/test/helpers/PercentAssertions.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 import {Test} from "forge-std/Test.sol";
 

--- a/test/helpers/ProposalTest.sol
+++ b/test/helpers/ProposalTest.sol
@@ -2,16 +2,16 @@
 pragma solidity ^0.8.23;
 
 import {Test} from "forge-std/Test.sol";
-import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-import {Deploy} from "script/Deploy.s.sol";
-import {DeployInput} from "script/DeployInput.sol";
-import {ProposeFactorySetOwner} from "script/ProposeFactorySetOwner.s.sol";
-import {ProposeProtocolFeesBatch1} from "script/ProposeProtocolFeesBatch1.sol";
-import {Constants} from "test/helpers/Constants.sol";
-import {GovernorBravoDelegate} from "script/interfaces/GovernorBravoInterfaces.sol";
-import {V3FactoryOwner} from "src/V3FactoryOwner.sol";
-import {UniStaker} from "src/UniStaker.sol";
+import {Deploy} from "unistaker-script/Deploy.s.sol";
+import {DeployInput} from "unistaker-script/DeployInput.sol";
+import {ProposeFactorySetOwner} from "unistaker-script/ProposeFactorySetOwner.s.sol";
+import {ProposeProtocolFeesBatch1} from "unistaker-script/ProposeProtocolFeesBatch1.sol";
+import {Constants} from "unistaker-test/helpers/Constants.sol";
+import {GovernorBravoDelegate} from "unistaker-script/interfaces/GovernorBravoInterfaces.sol";
+import {V3FactoryOwner} from "unistaker/V3FactoryOwner.sol";
+import {UniStaker} from "unistaker/UniStaker.sol";
 
 abstract contract ProposalTest is Test, DeployInput, Constants {
   //----------------- State and Setup ----------- //

--- a/test/helpers/UniStaker.handler.sol
+++ b/test/helpers/UniStaker.handler.sol
@@ -5,9 +5,9 @@ import {CommonBase} from "forge-std/Base.sol";
 import {StdCheats} from "forge-std/StdCheats.sol";
 import {StdUtils} from "forge-std/StdUtils.sol";
 import {console} from "forge-std/console.sol";
-import {AddressSet, LibAddressSet} from "../helpers/AddressSet.sol";
-import {UniStaker} from "src/UniStaker.sol";
-import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
+import {AddressSet, LibAddressSet} from "unistaker-test/helpers/AddressSet.sol";
+import {UniStaker} from "unistaker/UniStaker.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract UniStakerHandler is CommonBase, StdCheats, StdUtils {
   using LibAddressSet for AddressSet;

--- a/test/helpers/interfaces/IUniswapPool.sol
+++ b/test/helpers/interfaces/IUniswapPool.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.23;
 
-import {IUniswapV3PoolOwnerActions} from "src/interfaces/IUniswapV3PoolOwnerActions.sol";
+import {IUniswapV3PoolOwnerActions} from "unistaker/interfaces/IUniswapV3PoolOwnerActions.sol";
 
 interface IUniswapPool is IUniswapV3PoolOwnerActions {
   function slot0()

--- a/test/mocks/MockERC20Votes.sol
+++ b/test/mocks/MockERC20Votes.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
-import {IERC20Delegates} from "src/interfaces/IERC20Delegates.sol";
-import {ERC20, ERC20Permit} from "openzeppelin/token/ERC20/extensions/ERC20Permit.sol";
+import {IERC20Delegates} from "unistaker/interfaces/IERC20Delegates.sol";
+import {ERC20, ERC20Permit} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
 
 /// @dev An ERC20Permit token that allows for public minting and mocks the delegation methods used
 /// in ERC20Votes governance tokens. It does not included check pointing functionality. This

--- a/test/mocks/MockRewardReceiver.sol
+++ b/test/mocks/MockRewardReceiver.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
-import {INotifiableRewardReceiver} from "src/interfaces/INotifiableRewardReceiver.sol";
+import {INotifiableRewardReceiver} from "unistaker/interfaces/INotifiableRewardReceiver.sol";
 
 contract MockRewardReceiver is INotifiableRewardReceiver {
   uint256 public lastParam__notifyRewardAmount_amount;

--- a/test/mocks/MockUniswapV3Factory.sol
+++ b/test/mocks/MockUniswapV3Factory.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
-import {IUniswapV3FactoryOwnerActions} from "src/interfaces/IUniswapV3FactoryOwnerActions.sol";
+import {IUniswapV3FactoryOwnerActions} from "unistaker/interfaces/IUniswapV3FactoryOwnerActions.sol";
 
 contract MockUniswapV3Factory is IUniswapV3FactoryOwnerActions {
   address public lastParam__setOwner_owner;

--- a/test/mocks/MockUniswapV3Pool.sol
+++ b/test/mocks/MockUniswapV3Pool.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
-import {IUniswapV3PoolOwnerActions} from "src/interfaces/IUniswapV3PoolOwnerActions.sol";
+import {IUniswapV3PoolOwnerActions} from "unistaker/interfaces/IUniswapV3PoolOwnerActions.sol";
 
 contract MockUniswapV3Pool is IUniswapV3PoolOwnerActions {
   uint8 public lastParam__setFeeProtocol_feeProtocol0;


### PR DESCRIPTION
This PR contains a series of changes that make it easier to use UniStaker as dependency in other projects

* Loosen compiler directives so the project can be compiled by any version after the one
  used to build production UniStaker
* Move remappings to the remappings.txt file and add remappings for the local project itself,
  specifically for the core contracts, tests, and scripts
* Use remappings for imports throughout the project so that the files will compile when the
  project is itself a depedency in the lib directory
* Remove some unused imports
* Update to forge-std v1.9.7 and fix some tests where failures or warnings were exposed by the
  new version, and/or the latest stable version of Foundry